### PR TITLE
Potential fix for code scanning alert no. 2: Unused import

### DIFF
--- a/ui/interface.py
+++ b/ui/interface.py
@@ -42,7 +42,7 @@ from api.parse_profile import (
     extract_catalysts,
     extract_exotics,
 )
-from api.manifest import load_item_definitions, get_item_display
+from api.manifest import load_item_definitions
 from ui.settings import SettingsDialog, load_settings
 from ui.loading import LoadingDialog
 from ui.api_tester import ApiTesterDialog


### PR DESCRIPTION
Potential fix for [https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/2](https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/2)

To resolve the issue, the unused `get_item_display` import should be removed from the file `ui/interface.py`. This will eliminate the unnecessary dependency and improve code readability. The change does not affect existing functionality since `get_item_display` is not being used in the code.

Steps to fix:
1. Locate the import statement on line 45: `from api.manifest import load_item_definitions, get_item_display`.
2. Remove `get_item_display` from the import list, while retaining `load_item_definitions`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
