### PR TITLE
Potential fix for code scanning alert no. 16: Reflected server-side cross-site scripting

### DIFF
--- a/auth_server.py
+++ b/auth_server.py
@@ -3,6 +3,7 @@ import logging
 import threading
 import webbrowser
 from flask import Flask, request # type: ignore
+import html
 
 LOG_PATH = os.path.join(
     os.path.dirname(__file__), "RaidAssist", "logs", "auth_server.log"
@@ -26,7 +27,7 @@ def callback():
         logging.error(f"OAuth error: {error}")
         return (
             "<h3>Authentication failed.</h3>"
-            f"<p>Error from Bungie: <b>{error}</b></p>",
+            f"<p>Error from Bungie: <b>{html.escape(error)}</b></p>",
             400,
         )
     if not code:


### PR DESCRIPTION
Potential fix for [https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/16](https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/16)

To fix the issue, any user-provided input included in the HTML response needs to be properly sanitized or escaped. The `html.escape()` function from Python's standard library is an appropriate choice for escaping HTML content to prevent XSS attacks. This function converts special characters (e.g., `<`, `>`, `&`) into their HTML-safe equivalents.

**Steps to fix:**
1. Import the `html` module to access the `html.escape()` function.
2. Apply `html.escape()` to the `error` variable before including it in the HTML response on line 29.
3. Ensure this is done consistently for all user-provided inputs included in HTML responses elsewhere in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
