### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through an exception

### DIFF
--- a/auth_server.py
+++ b/auth_server.py
@@ -91,8 +91,8 @@ if FLASK_AVAILABLE:
             logger.error(f"Error in OAuth callback: {e}")
             return (
                 "<h3>🚫 Authentication Error</h3>"
-                + f"<p>An error occurred: {html.escape(str(e))}</p>"
-                + "<p>Please try again.</p>",
+                + "<p>An unexpected error occurred. Please try again later.</p>"
+                + "<p>If the issue persists, contact support.</p>",
                 500,
             )
 


### PR DESCRIPTION
Potential fix for [https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/18](https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/18)

The fix involves replacing the part of the code that exposes the exception's details (`str(e)`) with a generic error message for the end user. The detailed exception information will still be logged server-side for debugging purposes. Specifically:

1. Replace the line that includes `str(e)` in the user-facing message with a generic error string.
2. Ensure the detailed exception information is logged using `logger.error`.

This fix will ensure no sensitive internal details are exposed to end users while maintaining the application's debugging capability.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
