### PR TITLE
Potential fix for code scanning alert no. 29: Unreachable 'except' block

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -45,8 +45,6 @@ if QT_AVAILABLE:
         pass
 
         STANDARD_UI_AVAILABLE = True
-    except ImportError:
-        pass
 
 # Export available components
 __all__ = [


### PR DESCRIPTION
Potential fix for [https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/29](https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/29)

To resolve the issue, we need to remove the unreachable `except ImportError:` block on line 48. Since the first `except ImportError:` block (line 44) is more general and already handles the same exception type, there is no need for redundancy. Removing the unreachable block will improve code clarity and maintainability without altering functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
