### PR TITLE
Potential fix for code scanning alert no. 90: Unnecessary pass

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -42,7 +42,7 @@ if QT_AVAILABLE:
 
         OVERLAY_AVAILABLE = True
     except ImportError:
-        pass
+        # Handle failed overlay import gracefully
 
         STANDARD_UI_AVAILABLE = True
 


### PR DESCRIPTION
Potential fix for [https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/90](https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/90)

To fix the problem, the `pass` statement on line 45 should simply be removed. This makes the block cleaner and adheres to Python's best practices of avoiding unnecessary code. Since the block is syntactically valid without `pass`, no additional modifications are required.

Changes are limited to the `except ImportError:` block starting on line 44. No new methods, imports, or definitions are necessary, as this fix only involves the removal of the redundant statement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
