### PR TITLE
Fix overlay module import issue

### DIFF
--- a/ui/advanced_overlay.py
+++ b/ui/advanced_overlay.py
@@ -1,0 +1,7 @@
+"""Backwards compatibility module for advanced overlay.
+
+This module re-exports all public objects from :mod:`ui.overlay` so that
+existing imports using ``ui.advanced_overlay`` continue to work.
+"""
+
+from .overlay import *  # noqa: F401,F403

--- a/ui/overlay.py
+++ b/ui/overlay.py
@@ -88,7 +88,11 @@ except ImportError:
 
 # Always import these for type definitions
 from utils.logging_manager import get_logger, log_context
-from utils.error_handler import safe_execute, handle_exception
+# utils.error_handler provides ``safe_execute`` and ``handle_error`` for
+# generalised exception handling. ``handle_exception`` was never a public
+# helper, so attempting to import it causes an ImportError when this module
+# is loaded.  Import the correct helper instead.
+from utils.error_handler import safe_execute, handle_error
 
 
 class OverlayDisplayMode(Enum):


### PR DESCRIPTION
## Summary
- add `ui.advanced_overlay` wrapper so existing imports work
- fix wrong helper import in `ui.overlay`

## Testing
- `pytest -m "not gui" -q`


------
https://chatgpt.com/codex/tasks/task_e_68737ff719bc832290e6f698db71eebc