### PR TITLE
Potential fix for code scanning alert no. 98: Empty except

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -34,8 +34,9 @@ if QT_AVAILABLE:
         from .settings import SettingsDialog
 
         UI_AVAILABLE = True
-    except ImportError:
-        pass
+    except ImportError as e:
+        import logging
+        logging.warning("Failed to import UI components: %s. UI_AVAILABLE will remain False.", e)
 
     try:
         from .overlay import Overlay, create_overlay


### PR DESCRIPTION
Potential fix for [https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/98](https://github.com/Into-The-Grey/RaidAssist/security/code-scanning/98)

To fix this issue:
1. Modify the `except ImportError` block on line 37 to handle the exception appropriately. This can be done by adding a log message to indicate that the import failed and the `UI_AVAILABLE` flag will remain `False`.
2. Import the `logging` module if it is not already imported, to log the error message.
3. Ensure that the fallback mechanism (i.e., setting `UI_AVAILABLE` to `False`) is explicitly conveyed through the log message.

This approach maintains the existing functionality while improving the code's clarity and debuggability.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
